### PR TITLE
Podspec update

### DIFF
--- a/HTMLAttributedString.podspec
+++ b/HTMLAttributedString.podspec
@@ -2,11 +2,11 @@ Pod::Spec.new do |s|
   s.name         = "HTMLAttributedString"
   s.version      = "0.0.1"
   s.summary      = "Do not mess with NSRanges anymore; Mark up your strings for quick attributes."
-  s.homepage     = "https://github.com/mmislam101/HTMLAttributedString"
+  s.homepage     = "https://github.com/yichizhang/HTMLAttributedString"
   s.author       = { "Mohammed Islam" => "https://github.com/mmislam101" }
   s.license      = "unlicense"
 
-  s.source       = { :git => "https://github.com/mmislam101/HTMLAttributedString.git", :tag => "0.0.1" }
+  s.source       = { :git => "https://github.com/yichizhang/HTMLAttributedString.git", :tag => "0.0.1" }
 
   s.platform     = :ios, '6.0'
   s.source_files = 'HTMLAttributedString/HTMLAttributedString.{h,m}'

--- a/HTMLAttributedString.podspec
+++ b/HTMLAttributedString.podspec
@@ -1,13 +1,136 @@
+#
+#  Be sure to run `pod spec lint [HTMLAttributedString.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
 Pod::Spec.new do |s|
-  s.name         = 'HTMLAttributedString'
-  s.version      = '1.0.0'
-  s.summary      = 'HTMLAttributedString uses the power of iOS 7.0's initWithData:options:documentAttributes:error: to bring you the power of HTML and CSS into your everyday iOS development needs.'
-  s.author = {
-    'Mohammed Islam' => 'https://github.com/mmislam101'
-  }
-  s.source = {
-    :git => 'https://github.com/mmislam101/HTMLAttributedString.git',
-    :tag => '1.0.0'
-  }
-  s.source_files = 'Source/*.{h,m}'
+
+  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  These will help people to find your library, and whilst it
+  #  can feel like a chore to fill in it's definitely to your advantage. The
+  #  summary should be tweet-length, and the description more in depth.
+  #
+
+  s.name         = "[HTMLAttributedString"
+  s.version      = "0.0.1"
+  s.summary      = "A short description of [HTMLAttributedString."
+
+  s.description  = <<-DESC
+                   A longer description of [HTMLAttributedString in Markdown format.
+
+                   * Think: Why did you write this? What is the focus? What does it do?
+                   * CocoaPods will be using this to generate tags, and improve search results.
+                   * Try to keep it short, snappy and to the point.
+                   * Finally, don't worry about the indent, CocoaPods strips it!
+                   DESC
+
+  s.homepage     = "http://EXAMPLE/[HTMLAttributedString"
+  # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+
+
+  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Licensing your code is important. See http://choosealicense.com for more info.
+  #  CocoaPods will detect a license file if there is a named LICENSE*
+  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
+  #
+
+  s.license      = "MIT (example)"
+  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
+
+
+  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the authors of the library, with email addresses. Email addresses
+  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
+  #  accepts just a name if you'd rather not provide an email address.
+  #
+  #  Specify a social_media_url where others can refer to, for example a twitter
+  #  profile URL.
+  #
+  
+  s.author             = { "Yichi Zhang" => "zhang-yi-chi@hotmail.com" }
+  # Or just: s.author    = "Yichi Zhang"
+  # s.authors            = { "Yichi Zhang" => "zhang-yi-chi@hotmail.com" }
+  # s.social_media_url   = "http://twitter.com/Yichi Zhang"
+
+  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If this Pod runs only on iOS or OS X, then specify the platform and
+  #  the deployment target. You can optionally include the target after the platform.
+  #
+
+  # s.platform     = :ios
+  # s.platform     = :ios, "5.0"
+
+  #  When using multiple platforms
+  # s.ios.deployment_target = "5.0"
+  # s.osx.deployment_target = "10.7"
+
+
+  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the location from where the source should be retrieved.
+  #  Supports git, hg, bzr, svn and HTTP.
+  #
+
+  s.source       = { :git => "http://EXAMPLE/[HTMLAttributedString.git", :tag => "0.0.1" }
+
+
+  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  CocoaPods is smart about how it includes source code. For source files
+  #  giving a folder will include any h, m, mm, c & cpp files. For header
+  #  files it will include any header in the folder.
+  #  Not including the public_header_files will make all headers public.
+  #
+
+  s.source_files  = "Classes", "Classes/**/*.{h,m}"
+  s.exclude_files = "Classes/Exclude"
+
+  # s.public_header_files = "Classes/**/*.h"
+
+
+  # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  A list of resources included with the Pod. These are copied into the
+  #  target bundle with a build phase script. Anything else will be cleaned.
+  #  You can preserve files from being cleaned, please don't preserve
+  #  non-essential files like tests, examples and documentation.
+  #
+
+  # s.resource  = "icon.png"
+  # s.resources = "Resources/*.png"
+
+  # s.preserve_paths = "FilesToSave", "MoreFilesToSave"
+
+
+  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Link your library with frameworks, or libraries. Libraries do not include
+  #  the lib prefix of their name.
+  #
+
+  # s.framework  = "SomeFramework"
+  # s.frameworks = "SomeFramework", "AnotherFramework"
+
+  # s.library   = "iconv"
+  # s.libraries = "iconv", "xml2"
+
+
+  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If your library depends on compiler flags you can set them in the xcconfig hash
+  #  where they will only apply to your library. If you depend on other Podspecs
+  #  you can include multiple dependencies to ensure it works.
+
+  # s.requires_arc = true
+
+  # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
+  # s.dependency "JSONKit", "~> 1.4"
+
 end

--- a/HTMLAttributedString.podspec
+++ b/HTMLAttributedString.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name         = "HTMLAttributedString"
-  s.version      = "1.0.0"
+  s.version      = "0.0.1"
   s.summary      = "Do not mess with NSRanges anymore; Mark up your strings for quick attributes."
   s.homepage     = "https://github.com/mmislam101/HTMLAttributedString"
   s.author       = { "Mohammed Islam" => "https://github.com/mmislam101" }
   s.license      = "unlicense"
 
-  s.source       = { :git => "https://github.com/mmislam101/HTMLAttributedString.git", :tag => "1.0.0" }
+  s.source       = { :git => "https://github.com/mmislam101/HTMLAttributedString.git", :tag => "0.0.1" }
 
   s.platform     = :ios, '6.0'
   s.source_files = 'HTMLAttributedString/HTMLAttributedString.{h,m}'

--- a/HTMLAttributedString.podspec
+++ b/HTMLAttributedString.podspec
@@ -1,136 +1,14 @@
-#
-#  Be sure to run `pod spec lint [HTMLAttributedString.podspec' to ensure this is a
-#  valid spec and to remove all comments including this before submitting the spec.
-#
-#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
-#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
-#
-
 Pod::Spec.new do |s|
+  s.name         = "HTMLAttributedString"
+  s.version      = "1.0.0"
+  s.summary      = "Do not mess with NSRanges anymore; Mark up your strings for quick attributes."
+  s.homepage     = "https://github.com/mmislam101/HTMLAttributedString"
+  s.author       = { "Mohammed Islam" => "https://github.com/mmislam101" }
+  s.license      = "unlicense"
 
-  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  These will help people to find your library, and whilst it
-  #  can feel like a chore to fill in it's definitely to your advantage. The
-  #  summary should be tweet-length, and the description more in depth.
-  #
+  s.source       = { :git => "https://github.com/mmislam101/HTMLAttributedString.git", :tag => "1.0.0" }
 
-  s.name         = "[HTMLAttributedString"
-  s.version      = "0.0.1"
-  s.summary      = "A short description of [HTMLAttributedString."
-
-  s.description  = <<-DESC
-                   A longer description of [HTMLAttributedString in Markdown format.
-
-                   * Think: Why did you write this? What is the focus? What does it do?
-                   * CocoaPods will be using this to generate tags, and improve search results.
-                   * Try to keep it short, snappy and to the point.
-                   * Finally, don't worry about the indent, CocoaPods strips it!
-                   DESC
-
-  s.homepage     = "http://EXAMPLE/[HTMLAttributedString"
-  # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
-
-
-  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Licensing your code is important. See http://choosealicense.com for more info.
-  #  CocoaPods will detect a license file if there is a named LICENSE*
-  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
-  #
-
-  s.license      = "MIT (example)"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-
-
-  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Specify the authors of the library, with email addresses. Email addresses
-  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
-  #  accepts just a name if you'd rather not provide an email address.
-  #
-  #  Specify a social_media_url where others can refer to, for example a twitter
-  #  profile URL.
-  #
-  
-  s.author             = { "Yichi Zhang" => "zhang-yi-chi@hotmail.com" }
-  # Or just: s.author    = "Yichi Zhang"
-  # s.authors            = { "Yichi Zhang" => "zhang-yi-chi@hotmail.com" }
-  # s.social_media_url   = "http://twitter.com/Yichi Zhang"
-
-  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  If this Pod runs only on iOS or OS X, then specify the platform and
-  #  the deployment target. You can optionally include the target after the platform.
-  #
-
-  # s.platform     = :ios
-  # s.platform     = :ios, "5.0"
-
-  #  When using multiple platforms
-  # s.ios.deployment_target = "5.0"
-  # s.osx.deployment_target = "10.7"
-
-
-  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Specify the location from where the source should be retrieved.
-  #  Supports git, hg, bzr, svn and HTTP.
-  #
-
-  s.source       = { :git => "http://EXAMPLE/[HTMLAttributedString.git", :tag => "0.0.1" }
-
-
-  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  CocoaPods is smart about how it includes source code. For source files
-  #  giving a folder will include any h, m, mm, c & cpp files. For header
-  #  files it will include any header in the folder.
-  #  Not including the public_header_files will make all headers public.
-  #
-
-  s.source_files  = "Classes", "Classes/**/*.{h,m}"
-  s.exclude_files = "Classes/Exclude"
-
-  # s.public_header_files = "Classes/**/*.h"
-
-
-  # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  A list of resources included with the Pod. These are copied into the
-  #  target bundle with a build phase script. Anything else will be cleaned.
-  #  You can preserve files from being cleaned, please don't preserve
-  #  non-essential files like tests, examples and documentation.
-  #
-
-  # s.resource  = "icon.png"
-  # s.resources = "Resources/*.png"
-
-  # s.preserve_paths = "FilesToSave", "MoreFilesToSave"
-
-
-  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Link your library with frameworks, or libraries. Libraries do not include
-  #  the lib prefix of their name.
-  #
-
-  # s.framework  = "SomeFramework"
-  # s.frameworks = "SomeFramework", "AnotherFramework"
-
-  # s.library   = "iconv"
-  # s.libraries = "iconv", "xml2"
-
-
-  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  If your library depends on compiler flags you can set them in the xcconfig hash
-  #  where they will only apply to your library. If you depend on other Podspecs
-  #  you can include multiple dependencies to ensure it works.
-
-  # s.requires_arc = true
-
-  # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
-  # s.dependency "JSONKit", "~> 1.4"
-
+  s.platform     = :ios, '6.0'
+  s.source_files = 'HTMLAttributedString/HTMLAttributedString.{h,m}'
+  s.requires_arc = true
 end


### PR DESCRIPTION
The previous pod spec was erroneous, should have automatically generate the pod spec. 
Just type
$ pod spec create [NAME | https://github.com/USER/REPO]
within the project folder.

However there is still a problem, the terminal says

[!] /usr/bin/git fetch origin tags/0.0.1 2>&1
fatal: Couldn't find remote ref tags/0.0.1
fatal: The remote end hung up unexpectedly

Do you know what do they mean by 'tag'/'tags'?
